### PR TITLE
Storing question details in cache to avoid db interaction 

### DIFF
--- a/src/main/java/com/codecompiler/service/impl/CodeProcessingServiceImpl.java
+++ b/src/main/java/com/codecompiler/service/impl/CodeProcessingServiceImpl.java
@@ -13,6 +13,7 @@ import java.util.concurrent.*;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import com.codecompiler.dto.CodeDetailsDTO;
@@ -184,7 +185,7 @@ public class CodeProcessingServiceImpl implements CodeProcessingService {
 
     if (!complilationMessage.isEmpty()) {
       codeResponseDTO.setComplilationMessage(complilationMessage);
-      log.info("runORExecuteAllTestCases code :: compilation error :: " + complilationMessage);
+      log.info("runORExecuteAllTestCases code :: compilation error message :: " + complilationMessage);
       return codeResponseDTO;
     }
     String interpretationCommand = codeProcessingUtil.interpretationCommand(language, studentId);
@@ -193,10 +194,13 @@ public class CodeProcessingServiceImpl implements CodeProcessingService {
     } else {
       codeResponseDTO = executeSampleTestCase(questionId, interpretationCommand);
     }
+    log.info("executeStudentCode() -> end");
     return codeResponseDTO;
   }
 
-  private CodeResponseDTO executeAllTestCases(String questionId, String interpretationCommand) {
+  @Cacheable(value = "executeCodeForEveryTestcase", key = "#questionId")
+  public CodeResponseDTO executeAllTestCases(String questionId, String interpretationCommand) {
+    log.info("executeAllTestCases() -> started");
     CodeResponseDTO codeResponseDTO = new CodeResponseDTO();
     List<Callable<Boolean>> taskList = new ArrayList<Callable<Boolean>>();
     List<Future<Boolean>> futureList = new ArrayList<Future<Boolean>>();
@@ -231,10 +235,12 @@ public class CodeProcessingServiceImpl implements CodeProcessingService {
       taskList.clear();
     }
     codeResponseDTO.setTestCasesSuccess(testCasesResult);
+    log.info("executeAllTestCases() -> end");
     return codeResponseDTO;
   }
 
   private Boolean getTestCaseResponse(TestCases testCase, String interpretationCommand) {
+    log.info("executeAllTestCases() -> started");
     Boolean testCaseResponse;
     String input = testCase.getInput();
     String interpretationMessage = executeProcess(interpretationCommand + input);
@@ -246,10 +252,12 @@ public class CodeProcessingServiceImpl implements CodeProcessingService {
     } else {
       testCaseResponse = false;
     }
+    log.info("executeAllTestCases() -> end");
     return testCaseResponse;
   }
 
   private CodeResponseDTO executeSampleTestCase(String questionId, String interpretationCommand) {
+    log.info("executeSampleTestCase() -> started");
     CodeResponseDTO codeResponseDTO = new CodeResponseDTO();
     ArrayList<Boolean> testCasesSuccess = new ArrayList<Boolean>();
     TestCaseDTO testCases = questionService.getSampleTestCase(questionId);
@@ -270,6 +278,7 @@ public class CodeProcessingServiceImpl implements CodeProcessingService {
       testCasesSuccess.add(false);
     }
     codeResponseDTO.setTestCasesSuccess(testCasesSuccess);
+    log.info("executeSampleTestCase() -> end");
     return codeResponseDTO;
   }
 

--- a/src/test/java/com/codecompiler/CodeProcessingServiceTest.java
+++ b/src/test/java/com/codecompiler/CodeProcessingServiceTest.java
@@ -1,2 +1,48 @@
-package com.codecompiler;public class CodeProcessingServiceTest {
+package com.codecompiler;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.codecompiler.dto.CodeDetailsDTO;
+import com.codecompiler.dto.CodeResponseDTO;
+import com.codecompiler.dto.ExecuteAllTestCasesDTO;
+import com.codecompiler.service.CodeProcessingService;
+
+import lombok.extern.slf4j.Slf4j;
+
+@SpringBootTest
+@Slf4j
+public class CodeProcessingServiceTest {
+
+  @Autowired
+  private CodeProcessingService codeProcessingService;
+  private static ExecuteAllTestCasesDTO executeAllTestCasesDTO = new ExecuteAllTestCasesDTO();
+ private static  ExecuteAllTestCasesDTO executeAllTestCasesDTO1 = new ExecuteAllTestCasesDTO();
+  @BeforeEach
+  void initializeObject() {
+    executeAllTestCasesDTO.setStudentId("4150cb93-7973-4996-ad68-d5cc85debef4");
+    executeAllTestCasesDTO.setQuestionId("70825abb-5f57-4400-a656-c8627f5ebe46"); // ad79957b-75c0-4ec8-abff-77bcd580dc25
+    executeAllTestCasesDTO.setLanguage("Java");
+    executeAllTestCasesDTO.setFlag(1);
+    executeAllTestCasesDTO.setCode("public class Main{\n  public static void main(String args[]){\n// \tint n = Integer.parseInt(args[0]); // taking parameter from command line and convert to int\n \n \t//write your code here\n       \n    String str = \"\";\n    String s = args[0];\n    \n    for(int i=s.length()-1; i>=0; i--)\n      str+=s.charAt(i);\n      \n    System.out.println(str);\n  }\n}");
+
+    executeAllTestCasesDTO1.setStudentId("522376b5-5dd2-4fe1-9de8-eeef5f9cfe04");
+    executeAllTestCasesDTO1.setQuestionId("baa50b79-f39d-4358-bf68-c2552b82b406");
+    executeAllTestCasesDTO1.setLanguage("Java");
+    executeAllTestCasesDTO1.setFlag(1);
+    executeAllTestCasesDTO1.setCode("public class Main{\n public static void main(String args[]){\n int input = Integer.parseInt(args[0]); \n int factorial = 0; \n\n	if(input == 0) \nthrow new RuntimeException('invalid input');\n \n	for(int number = 1; number <=input; number++) \n factorial *= number;\n	System.out.println(factorial); \n }\n}");
+
+  }
+  @Test
+  public void compileCodeSuccessTest() throws IOException {
+    for (int i=0; i<50; i++) {
+      CodeResponseDTO codeResponse = codeProcessingService.runORExecuteAllTestCases(executeAllTestCasesDTO);
+      Assertions.assertNotNull(codeResponse.getTestCasesSuccess()!=null);
+    }
+  }
 }


### PR DESCRIPTION
RCA
-------------------------
**Issue:-** Db interaction taking time for fetching questions detail. Even though the question is expected every time. 

**Resolution:-** I'm storing question details in the cache using a key as a questionId to avoid common DB interaction for the 
                        same data. Wrote test cases for the same changes and tested in bulk operations. 

**File modified:-** src/main/java/com/codecompiler/service/impl/CodeProcessingServiceImpl.java
                        src/test/java/com/codecompiler/CodeProcessingServiceTest.java
                        
 **Reviewers:-** Shivani Ghosle 